### PR TITLE
External config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,29 @@
 ## Update
 `sudo nixos-rebuild switch --flake .#hostname`
 `home-manager switch --flake .#username@hostname`
+
+## File Assertions (`nixos/modules/file-assertions.nix`)
+An attempt at a solution to the problem of secrets in nixos.
+I am not a fan of storing encrypted secrets in plainview (as occurs with sops/age).
+It feels like there is somewhat of a consensus that nixos must be hermetic, thus all files
+(including those containing secrets) must be managed by nix. But this isn't event true for sops/age,
+since the private key used to encrypt everything is not managed by nix.
+If sops/age rely on the non-hermetic machine environment, while still maintaining
+a level of reasonable declarative-ness, why can't I do the same?
+I can declare any number of files that expected to exist (and where), and specify
+whether them not existing should break the build (fatal/assert) or just warn.
+This feels like it could be an ok solution for secrets (could be better to support sops/age for encryption as well)
+and a very good solution for instance specify config (relating to the unique setup of a given machine from a shared config)
+like ssh keys, and wireguard configuration
+
+This solution could arguably be made better by requiring hashes for the files that can be checked against.
+
+### sysconfig
+Basic example for wireguard, but can be extended to any config file.
+Create a local directory `/etc/nixos/sysconfig`:
+- `etc`
+ - `wireguard`
+  - `wg0.conf`
+containing the instance's unique wireguard config.
+From `sysconfig` run `sudo stow -t / .` to add config to etc.
+This can be undone with `sudo stow -D -t / .`

--- a/README.md
+++ b/README.md
@@ -9,20 +9,19 @@
 `home-manager switch --flake .#username@hostname`
 
 ## File Assertions (`nixos/modules/file-assertions.nix`)
-An attempt at a solution to the problem of secrets in nixos.
+(An attempt at a solution to the problem of secrets in nixos.)
+
 I am not a fan of storing encrypted secrets in plainview (as occurs with sops/age).
 It feels like there is somewhat of a consensus that nixos must be hermetic, thus all files
-(including those containing secrets) must be managed by nix. But this isn't event true for sops/age,
+(including those containing secrets) must be managed by nix. But this isn't even true for sops/age,
 since the private key used to encrypt everything is not managed by nix.
 If sops/age rely on the non-hermetic machine environment, while still maintaining
 a level of reasonable declarative-ness, why can't I do the same?
-I can declare any number of files that expected to exist (and where), and specify
-whether them not existing should break the build (fatal/assert) or just warn.
-This feels like it could be an ok solution for secrets (could be better to support sops/age for encryption as well)
-and a very good solution for instance specify config (relating to the unique setup of a given machine from a shared config)
-like ssh keys, and wireguard configuration
 
-This solution could arguably be made better by requiring hashes for the files that can be checked against.
+With `file-assertions` I can declare any number of files that are expected to exist (and where), and specify
+whether them not existing should break the build or just warn (fatal = true or false).
+These checks are handled at build time as they require access to files outside of the sandbox,
+thus the result of the checks can be used during eval time, however than can be used for activation and run time.
 
 ### sysconfig
 Basic example for wireguard, but can be extended to any config file.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ thus the result of the checks can be used during eval time, however than can be 
 
 ### sysconfig
 Basic example for wireguard, but can be extended to any config file.
-Create a local directory `/etc/nixos/sysconfig`:
-- `etc`
- - `wireguard`
-  - `wg0.conf`
+- Create a local directory `/etc/nixos/sysconfig`:
+ - `etc`
+  - `wireguard`
+   - `wg0.conf`
 containing the instance's unique wireguard config.
-From `sysconfig` run `sudo stow -t / .` to add config to etc.
-This can be undone with `sudo stow -D -t / .`
+- From `sysconfig` run `sudo stow -t / .` to add config to etc.
+ - This can be undone with `sudo stow -D -t / .`
+- Add a systemd.services.wg0 to handle startup of the tunnel automatically
+- Or, alternatively, handle manually at runtime with `wg-quick <up|down> wg0`

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ thus the result of the checks can be used during eval time, however than can be 
 ### sysconfig
 Basic example for wireguard, but can be extended to any config file.
 - Create a local directory `/etc/nixos/sysconfig`:
- - `etc`
-  - `wireguard`
-   - `wg0.conf`
+  - `etc`
+    - `wireguard`
+      - `wg0.conf`
 containing the instance's unique wireguard config.
 - From `sysconfig` run `sudo stow -t / .` to add config to etc.
- - This can be undone with `sudo stow -D -t / .`
+  - This can be undone with `sudo stow -D -t / .`
 - Add a systemd.services.wg0 to handle startup of the tunnel automatically
 - Or, alternatively, handle manually at runtime with `wg-quick <up|down> wg0`

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ thus the result of the checks can be used during eval time, however than can be 
 ### sysconfig
 Basic example for wireguard, but can be extended to any config file.
 - Create a local directory `/etc/nixos/sysconfig`:
-  - `etc`
-    - `wireguard`
-      - `wg0.conf`
+    - `etc`
+        - `wireguard`
+            - `wg0.conf`
 containing the instance's unique wireguard config.
 - From `sysconfig` run `sudo stow -t / .` to add config to etc.
-  - This can be undone with `sudo stow -D -t / .`
+    - This can be undone with `sudo stow -D -t / .`
 - Add a systemd.services.wg0 to handle startup of the tunnel automatically
 - Or, alternatively, handle manually at runtime with `wg-quick <up|down> wg0`

--- a/nixos/modules/file-assertions.nix
+++ b/nixos/modules/file-assertions.nix
@@ -1,17 +1,13 @@
 { config, lib, pkgs, ... }:
 let
   formatError = msg: ''echo -e "\033[1;31mERROR:\033[0m ${msg}" >&2'';
-  formatWarning = msg: ''echo -e "\033[1;33mWARNING:\033[0m ${msg}" >&2'';
+  # NOTE: ESC must be used (typed with ctrl+v ESC (ascii 27))
+  formatWarning = msg: builtins.trace "[1;33mWARNING:[0m ${msg}" "echo ''";
 
   assert_file = { path_str, msg, fatal }: pkgs.stdenv.mkDerivation {
     name = "assert-${(baseNameOf path_str)}";
-    # __noChroot = true;  # Allow host filesystem access
     phases = [ "buildPhase" "installPhase" ];
     buildPhase = ''
-      # echo "Sandbox contents:"
-      # ls -la /
-      # ls -la /etc/wireguard
-
       if [ ! -e "${path_str}" ]; then
         ${
           (if fatal then formatError else formatWarning)
@@ -20,7 +16,7 @@ let
         ${if fatal then "exit 1" else ""}
       fi
     '';
-    installPhase = "mkdir -p $out";  # Required output
+    installPhase = "mkdir -p $out";
   };
 in
 {
@@ -44,27 +40,15 @@ in
   config = {
     system.checks = map (f: assert_file f) config.fileAssertions;
 
-    # nix.extraOptions = ''
-    #   extra-sandbox-paths ${toString ((lib.unique (map (f: dirOf f.path_str) config.fileAssertions))
-    #     ++ config.extraSandboxPaths)}
-    # '';
-
     nix.settings =
     let
       addPaths = (lib.unique (map (f: dirOf f.path_str) config.fileAssertions))
         ++ config.extraSandboxPaths;
     in
     {
-      # trusted-users = [ "@wheel" ];
-      # sandbox = "relaxed";
-      extra-sandbox-paths = addPaths;
-      # extra-sandbox-paths = lib.mkForce addPaths;
-      # extra-sandbox-paths = lib.unique (map (f: dirOf f.path_str) config.fileAssertions);
-      # extra-sandbox-paths =
-      #   let
-      #     dirs = map (f: dirOf f.path_str) config.fileAssertions;
-      #     uniqueDirs = lib.unique dirs;
-      #   in lib.trace "Adding to sandbox: ${toString uniqueDirs}" uniqueDirs;
+      extra-sandbox-paths = builtins.trace
+        "Adding [${lib.concatStringsSep ", " addPaths}] to extra-sandbox-paths"
+        addPaths;
     };
   };
 }

--- a/nixos/modules/file-assertions.nix
+++ b/nixos/modules/file-assertions.nix
@@ -1,32 +1,70 @@
-# NOTE: requires running with --impure
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
+let
+  formatError = msg: ''echo -e "\033[1;31mERROR:\033[0m ${msg}" >&2'';
+  formatWarning = msg: ''echo -e "\033[1;33mWARNING:\033[0m ${msg}" >&2'';
+
+  assert_file = { path_str, msg, fatal }: pkgs.stdenv.mkDerivation {
+    name = "assert-${(baseNameOf path_str)}";
+    # __noChroot = true;  # Allow host filesystem access
+    phases = [ "buildPhase" "installPhase" ];
+    buildPhase = ''
+      # echo "Sandbox contents:"
+      # ls -la /
+      # ls -la /etc/wireguard
+
+      if [ ! -e "${path_str}" ]; then
+        ${
+          (if fatal then formatError else formatWarning)
+          (if msg != "" then msg else "Missing file: ${path_str}")
+        }
+        ${if fatal then "exit 1" else ""}
+      fi
+    '';
+    installPhase = "mkdir -p $out";  # Required output
+  };
+in
 {
   options = {
     fileAssertions = lib.mkOption {
       type = lib.types.listOf (lib.types.submodule {
         options = {
-          path = lib.mkOption { type = lib.types.str; };
-          message = lib.mkOption { type = lib.types.str; default = ""; };
+          path_str = lib.mkOption { type = lib.types.str; };
+          msg = lib.mkOption { type = lib.types.str; default = ""; };
           fatal = lib.mkOption { type = lib.types.bool; default = true; };
         };
       });
       default = [];
     };
+    extraSandboxPaths = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+    };
   };
 
-  config =
-  let
-    msg_or_def = (m: p: if m != "" then m else "Missing required file: ${p}");
-  in
-  {
-    assertions = map
-      (e: { assertion = builtins.pathExists e.path; message = msg_or_def e.message e.path; })
-      (lib.filter (check: check.fatal) config.fileAssertions)
-    ;
+  config = {
+    system.checks = map (f: assert_file f) config.fileAssertions;
 
-    warnings = map
-      (e: msg_or_def e.message e.path)
-      (lib.filter (check: !check.fatal && !(builtins.pathExists check.path)) config.fileAssertions)
-    ;
+    # nix.extraOptions = ''
+    #   extra-sandbox-paths ${toString ((lib.unique (map (f: dirOf f.path_str) config.fileAssertions))
+    #     ++ config.extraSandboxPaths)}
+    # '';
+
+    nix.settings =
+    let
+      addPaths = (lib.unique (map (f: dirOf f.path_str) config.fileAssertions))
+        ++ config.extraSandboxPaths;
+    in
+    {
+      # trusted-users = [ "@wheel" ];
+      # sandbox = "relaxed";
+      extra-sandbox-paths = addPaths;
+      # extra-sandbox-paths = lib.mkForce addPaths;
+      # extra-sandbox-paths = lib.unique (map (f: dirOf f.path_str) config.fileAssertions);
+      # extra-sandbox-paths =
+      #   let
+      #     dirs = map (f: dirOf f.path_str) config.fileAssertions;
+      #     uniqueDirs = lib.unique dirs;
+      #   in lib.trace "Adding to sandbox: ${toString uniqueDirs}" uniqueDirs;
+    };
   };
 }

--- a/nixos/modules/file-assertions.nix
+++ b/nixos/modules/file-assertions.nix
@@ -1,0 +1,32 @@
+# NOTE: requires running with --impure
+{ config, lib, ... }:
+{
+  options = {
+    fileAssertions = lib.mkOption {
+      type = lib.types.listOf (lib.types.submodule {
+        options = {
+          path = lib.mkOption { type = lib.types.str; };
+          message = lib.mkOption { type = lib.types.str; default = ""; };
+          fatal = lib.mkOption { type = lib.types.bool; default = true; };
+        };
+      });
+      default = [];
+    };
+  };
+
+  config =
+  let
+    msg_or_def = (m: p: if m != "" then m else "Missing required file: ${p}");
+  in
+  {
+    assertions = map
+      (e: { assertion = builtins.pathExists e.path; message = msg_or_def e.message e.path; })
+      (lib.filter (check: check.fatal) config.fileAssertions)
+    ;
+
+    warnings = map
+      (e: msg_or_def e.message e.path)
+      (lib.filter (check: !check.fatal && !(builtins.pathExists check.path)) config.fileAssertions)
+    ;
+  };
+}

--- a/nixos/prodesk/configuration.nix
+++ b/nixos/prodesk/configuration.nix
@@ -20,7 +20,6 @@
   # otherwise a weird issue with extra-sandbox-paths doesn't allow the files to be seen
   fileAssertions = [
     { path_str = "/etc/wireguard/wg0.conf"; }
-    # { path_str = "/etc/wireguard/wg1.conf"; fatal = false; }  # test warning
   ];
   # NOTE: if using symlinks add symlinked dir as extra path
   # it sometimes works without, but is super spotty
@@ -29,6 +28,7 @@
   # Bootloader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
+  boot.kernelModules = [ "wireguard" ];
 
   networking.hostName = "prodesk"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
@@ -118,6 +118,7 @@
     vim
     home-manager
     stow
+    wireguard-tools
   ];
 
   programs = {

--- a/nixos/prodesk/configuration.nix
+++ b/nixos/prodesk/configuration.nix
@@ -17,10 +17,11 @@
   ];
 
   fileAssertions = [
-    { path = "/etc/wireguard/wg0.conf"; }
-    # { path = "/etc/nixos/sysconf/wireguard/wg0.conf"; }
-    # { path = "/home/admin/TEST"; }
+    { path_str = "/etc/wireguard/wg0.conf"; }
+    # { path_str = "/etc/wireguard/wg1.conf"; }
+    # { path_str = "/etc/wireguard/wg1.conf"; fatal = false; }
   ];
+  # extraSandboxPaths = [ "/etc/nixos/sysconf" ];
 
   # Bootloader.
   boot.loader.systemd-boot.enable = true;

--- a/nixos/prodesk/configuration.nix
+++ b/nixos/prodesk/configuration.nix
@@ -16,12 +16,15 @@
     })
   ];
 
+  # NOTE: all new paths need to be added and built with fatal = false first
+  # otherwise a weird issue with extra-sandbox-paths doesn't allow the files to be seen
   fileAssertions = [
     { path_str = "/etc/wireguard/wg0.conf"; }
-    # { path_str = "/etc/wireguard/wg1.conf"; }
-    # { path_str = "/etc/wireguard/wg1.conf"; fatal = false; }
+    # { path_str = "/etc/wireguard/wg1.conf"; fatal = false; }  # test warning
   ];
-  # extraSandboxPaths = [ "/etc/nixos/sysconf" ];
+  # NOTE: if using symlinks add symlinked dir as extra path
+  # it sometimes works without, but is super spotty
+  extraSandboxPaths = [ "/etc/nixos/sysconf" ];
 
   # Bootloader.
   boot.loader.systemd-boot.enable = true;

--- a/nixos/prodesk/configuration.nix
+++ b/nixos/prodesk/configuration.nix
@@ -3,6 +3,7 @@
   imports = [
     ./hardware-configuration.nix
     ../modules/print-server.nix
+    ../modules/file-assertions.nix
 
     # NOTE: Only update on boot to avoid service conflicts:
     # `sudo nixos-rebuild boot --flake .`
@@ -13,6 +14,12 @@
       sName = "fabric-server";
       replacements = { HOST_PORT = "25565"; MAX_MEMORY = "8G"; };
     })
+  ];
+
+  fileAssertions = [
+    { path = "/etc/wireguard/wg0.conf"; }
+    # { path = "/etc/nixos/sysconf/wireguard/wg0.conf"; }
+    # { path = "/home/admin/TEST"; }
   ];
 
   # Bootloader.
@@ -106,6 +113,7 @@
   environment.systemPackages = with pkgs; [
     vim
     home-manager
+    stow
   ];
 
   programs = {


### PR DESCRIPTION
Another method for managing instance specific files (and thus file-based secrets). Implemented with a focus on wireguard, but is extendable to any files that are needed at runtime. One limitation of this approach is that it's limited to build time checks so you still can use the results to inform eval time config settings. However, it still fails (or warns) loudly which helps maintain a declarative setup, even though the files themselves are managed outside of nix.